### PR TITLE
Demo: make dependency+lint failures PR-fixable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
         if: ${{ github.event.inputs.failure_type == 'dependency' }}
         run: |
           echo "Simulating dependency failure..."
-          bun add nonexistent-package-xyz@999.999.999
+          # Trigger a deterministic "Cannot find module" error that PipelineHealer can auto-fix
+          # by adding the missing dependency to package.json.
+          node -e "require('left-pad')"
       
       # Lint step
       - name: Lint
@@ -56,7 +58,9 @@ jobs:
         run: |
           echo "Simulating lint failure..."
           echo "const x = 1" > temp.js
-          bunx eslint temp.js --rule 'semi: error'
+          # ESLint v9+ requires eslint.config.js by default; missing it produces a clear failure
+          # that PipelineHealer can remediate by opening a PR that adds the config.
+          bunx eslint temp.js
       
       # Build step
       - name: Build

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ When a failure occurs, PipelineHealer will:
 
 ### Dependency Failure
 - **Trigger**: Select `dependency` failure type
-- **Expected**: PipelineHealer creates a PR or issue about the missing package
+- **Expected (Recommended)**: PipelineHealer creates a PR that adds the missing dependency to `package.json`
 
 ### Lint Failure
 - **Trigger**: Select `lint` failure type
-- **Expected**: PipelineHealer creates an issue with lint violation details
+- **Expected (Recommended)**: PipelineHealer creates a PR that adds `eslint.config.js` (ESLint flat config)
 
 ### Test Failure
 - **Trigger**: Select `test` failure type


### PR DESCRIPTION
Updates the demo workflow so dependency + lint failures become deterministic and auto-remediable PR scenarios.

- dependency: use a missing module ("Cannot find module") instead of installing a nonexistent package
- lint: trigger ESLint v9 flat-config missing failure (PipelineHealer opens PR adding eslint.config.js)
